### PR TITLE
Fixing JNI issue when larget dataset is used and some other changes

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -2,21 +2,25 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="edu.sinica.citi.mac.android.actclassification"
     android:versionCode="1"
-    android:versionName="1.0" >
+    android:versionName="1.0" 
+    >
 
     <uses-sdk
-        android:minSdkVersion="8"
-        android:targetSdkVersion="19" />
+        android:minSdkVersion="14"
+        android:targetSdkVersion="19" 
+        />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 
     <application
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
+        android:largeHeap="true"
         >
         <activity
             android:name="edu.sinica.citi.mac.android.actclassification.ActClassificationActivity"
-            android:label="@string/app_name" >
+            android:label="@string/app_name" 
+            >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -30,6 +30,12 @@ LOCAL_NDK_VERSION := 4
 LOCAL_SDK_VERSION := 10
 
 LOCAL_MODULE    := libLibsvmAndroid
-LOCAL_LDLIBS := -llog
+#LOCAL_LDLIBS := -llog
+
+#newly added
+LOCAL_LDLIBS += -llog -ldl -landroid -lGLESv2 -lEGL 
+
+CPPFLAGS += -fno-strict-aliasing -mfpu=vfp -mfloat-abi=softfp
+LOCAL_CPP_FEATURES := rtti exceptions
 
 include $(BUILD_SHARED_LIBRARY)

--- a/jni/Application.mk
+++ b/jni/Application.mk
@@ -1,5 +1,11 @@
 # To build all native files, run ndk-build in the ../eegpoc directory.
 
-APP_ABI := armeabi
+#APP_ABI := armeabi
+#APP_OPTIM := release #original
 
-APP_OPTIM := release
+
+APP_STL := gnustl_static
+APP_CPPFLAGS := -frtti -fexceptions
+APP_ABI := armeabi
+APP_PLATFORM := android-14
+APP_OPTIM := debug

--- a/others/featConverter.py
+++ b/others/featConverter.py
@@ -21,7 +21,7 @@ import sys
 import csv
 
 
-def convert2libfmnew(X_file, Y_file, out_file):
+def convert2libfm(X_file, Y_file, out_file):
     ## output -> LIBSVM (txt)
     fin = open(X_file, 'rb')
     feat_list = list(csv.reader(fin, delimiter=','))
@@ -53,7 +53,7 @@ Only used when intent is to generate an out_file
 but there's no Y file and only src_file needs to be transformed into libsvm
 """
 
-def convert2libfm(X_file, out_file):
+def convert2libfmnew(X_file, out_file):
     ## output -> LIBSVM (txt)
     fin = open(X_file, 'rb')
     feat_list = list(csv.reader(fin, delimiter=','))
@@ -133,7 +133,7 @@ def print_usage():
     print "note:"
     print "* For inputFormat is libsvm, we will parse the label-feature-integrated libsvm file and split it into two files"
     print "* On the other hand, if you type csv as the inputFormat, we will integrate the src_file and Y_file into the out_file"
-    print "* If there is no Y_file and just src_file needs to be converted then just write blank e.g [src_file] blank [out_file] [inputFormat]"
+    print "* If there is no Y_file and just src_file needs to be converted then just write blank e.g [src_file] blank [out_file e.g Xte.libsvm] [inputFormat]"
 
 if __name__ == '__main__':
     if len(sys.argv) < 5:
@@ -147,9 +147,9 @@ if __name__ == '__main__':
 
         if inputFormat == 'csv':
             if Y_file == 'blank':
-                convert2libfm(src_file, out_file)
+                convert2libfmnew(src_file, out_file)
             else:
-                convert2libfmnew(src_file, Y_file, out_file)
+                convert2libfm(src_file, Y_file, out_file)
 
         elif inputFormat == 'libsvm':
             convert2matlab(src_file, Y_file, out_file)

--- a/others/featConverter.py
+++ b/others/featConverter.py
@@ -21,7 +21,7 @@ import sys
 import csv
 
 
-def convert2libfm(X_file, Y_file, out_file):
+def convert2libfmnew(X_file, Y_file, out_file):
     ## output -> LIBSVM (txt)
     fin = open(X_file, 'rb')
     feat_list = list(csv.reader(fin, delimiter=','))
@@ -133,7 +133,7 @@ def print_usage():
     print "note:"
     print "* For inputFormat is libsvm, we will parse the label-feature-integrated libsvm file and split it into two files"
     print "* On the other hand, if you type csv as the inputFormat, we will integrate the src_file and Y_file into the out_file"
-    print "* If there is no Y_file and just src_file needs to be converted then just write blank e.g [src_file] [Y_file] blnak [inputFormat]"
+    print "* If there is no Y_file and just src_file needs to be converted then just write blank e.g [src_file] blank [out_file] [inputFormat]"
 
 if __name__ == '__main__':
     if len(sys.argv) < 5:
@@ -144,14 +144,17 @@ if __name__ == '__main__':
         out_file    = sys.argv[3]
         inputFormat = sys.argv[4]
 
+
         if inputFormat == 'csv':
             if Y_file == 'blank':
                 convert2libfm(src_file, out_file)
             else:
-                convert2libfm(src_file, Y_file, out_file)
+                convert2libfmnew(src_file, Y_file, out_file)
 
         elif inputFormat == 'libsvm':
             convert2matlab(src_file, Y_file, out_file)
         
+
+
 
 


### PR DESCRIPTION
This commit includes couple of changes and fixes. Last time, I added a new feautre in featConvertor.py and I noticed that i made a typo error in the help section. Also the overloading of functions was giving error for somereason so I changed the function name to allow generating Xte.libsvm without hassle. 

Secondly, major work involves fixing error "JNI ERROR (app bug): local reference table overflow (max=512)" when I tried to use a subset of my csv dataset with 500 rows even. I made changes in Manifest.xml and AndroidJNI_source.cpp which has the main fixes. I also added some new flags in Android.mk and Application.mk for better execution and debug mode in C/C++.
